### PR TITLE
Enable Heroku review apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby File.read('.ruby-version').chomp
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.2', '>= 7.0.2.2'

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV

--- a/app.json
+++ b/app.json
@@ -1,0 +1,40 @@
+{
+	"name": "Foreign travel content checker",
+	"repository": "https://github.com/alphagov/foreign-travel-content-checker",
+	"env": {
+		"GOVUK_APP_DOMAIN": {
+			"value": "www.gov.uk"
+		},
+		"GOVUK_ASSET_ROOT": {
+			"value": "https://foreign-travel-content-checker.herokuapp.com"
+		},
+		"GOVUK_WEBSITE_ROOT": {
+			"value": "https://www.gov.uk"
+		},
+		"PLEK_SERVICE_CONTENT_STORE_URI": {
+			"value": "https://www.gov.uk/api"
+		},
+		"PLEK_SERVICE_SEARCH_URI": {
+			"value": "https://www.gov.uk/api"
+		},
+		"PLEK_SERVICE_STATIC_URI": {
+			"value": "assets.digital.cabinet-office.gov.uk"
+		},
+		"RAILS_SERVE_STATIC_ASSETS": {
+			"value": "yes"
+		},
+		"SECRET_KEY_BASE": {
+			"generator": "secret"
+		},
+		"HEROKU_APP_NAME": {
+			"required": true
+		}
+	},
+	"image": "heroku/ruby",
+	"buildpacks": [
+		{
+			"url": "https://github.com/heroku/heroku-buildpack-ruby"
+		}
+	],
+	"addons": []
+}


### PR DESCRIPTION
This change will allow us to deploy the application to Heroku and therefore enable review apps for each PR.

[Trello](https://trello.com/c/gTnbKiF1/673-move-the-foreign-travel-deep-link-checker-application-to-alphagov-govuks-heroku)